### PR TITLE
Fix possible bug object.rs

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -62,7 +62,7 @@ impl MLineStyleElement {
 //------------------------------------------------------------------------------
 impl DataTable {
     pub(crate) fn set_value(&mut self, row: usize, col: usize, val: DataTableValue) {
-        if row <= self.row_count && col <= self.column_count {
+        if row < self.row_count && col < self.column_count {
             self.values[row][col] = Some(val);
         }
     }


### PR DESCRIPTION
It makes no sense to allow row or col to go exactly to the row count when indexing is 0-based.

I have some test dxfs that fails to be parsed.